### PR TITLE
Bump vcs/git to 2.30.0-rc0

### DIFF
--- a/multi-arch/packages/git/definition.yaml
+++ b/multi-arch/packages/git/definition.yaml
@@ -1,6 +1,6 @@
 name: git
 category: vcs
-version: "2.29.2"
+version: "2.30.0"
 requires:
   - name: musl
     category: system


### PR DESCRIPTION
We're gits of the round table! | We eat ham and jam and commitalot! | On second thought, let's not go to #gitalot. It is a silly place.