### PR TITLE
Bump lang/go to 1.16.4

### DIFF
--- a/packages/go/definition.yaml
+++ b/packages/go/definition.yaml
@@ -1,6 +1,6 @@
 name: go
 category: lang
-version: "1.16.3"
+version: "1.16.4"
 labels:
   github.repo: "go"
   github.owner: "golang"


### PR DESCRIPTION
walks UDP package into bar A.